### PR TITLE
Add Windows support

### DIFF
--- a/git-http-server.js
+++ b/git-http-server.js
@@ -9,7 +9,7 @@
 
 var http = require('http');
 var spawn = require('child_process').spawn;
-var path = require('path');
+var path = require('path').posix;
 var url = require('url');
 
 var accesslog = require('access-log');


### PR DESCRIPTION
This fixes a minor path problem that was causing git-http-server to return 400 errors when running on Windows.